### PR TITLE
Don't check only for RUN command - all of them might be multiline

### DIFF
--- a/common_docker_steps.py
+++ b/common_docker_steps.py
@@ -57,7 +57,7 @@ def check_for_unknown_instructions(context):
             last_instruction = line.split(' ')[0]
             instructions.append(last_instruction)
 
-        if last_instruction == 'RUN' and line[-1] == '\\':
+        if line[-1] == '\\':
             line_continuation = True
         else:
             line_continuation = False


### PR DESCRIPTION
This failed for LABEL commands which are often split into multiple lines.
